### PR TITLE
fix: keep the HF Space iframe sized to the app's real height

### DIFF
--- a/iscc_sct/demo.py
+++ b/iscc_sct/demo.py
@@ -21,6 +21,28 @@ custom_css = """
 }
 """
 
+# Gradio's embedded-height reporter (js/core Blocks.svelte) stops growing the HF Space iframe
+# after a few consecutive height increases (circuit breaker for vh-feedback loops). Progressive
+# rendering of results trips it, freezing the iframe height and making everything below the fold
+# unreachable - the Space iframe has scrolling="no", so the mouse wheel is dead too. Report the
+# true document height to the iframe-resizer parent ourselves whenever it changes.
+custom_head = """
+<script>
+(function () {
+    if (window.self === window.top) return;  // only needed when embedded on HF Spaces
+    var last = 0;
+    setInterval(function () {
+        if (!window.parentIFrame) return;
+        var height = Math.ceil(document.body.scrollHeight) + 32;
+        if (Math.abs(height - last) > 2 && height < 32768) {
+            last = height;
+            window.parentIFrame.size(height);
+        }
+    }, 300);
+})();
+</script>
+"""
+
 
 newline_symbols = {
     "\u000a": "⏎",  # Line Feed - Represented by the 'Return' symbol
@@ -138,8 +160,8 @@ iscc_theme = gr.themes.Default(
     radius_size=gr.themes.sizes.radius_none,
 )
 
-# Gradio 6 expects theme and css as launch() parameters - pass these at every launch site
-launch_kwargs = {"theme": iscc_theme, "css": custom_css}
+# Gradio 6 expects theme, css and head as launch() parameters - pass these at every launch site
+launch_kwargs = {"theme": iscc_theme, "css": custom_css, "head": custom_head}
 
 with gr.Blocks() as demo:
     with gr.Row(variant="panel"):


### PR DESCRIPTION
## Root cause

Gradio 6's embedded-height reporter (`js/core/src/Blocks.svelte`, `handle_resize`) has a circuit breaker that stops reporting height **growth** to the Hugging Face parent page after 4 consecutive increases (guard against `vh`/`fill_height` feedback loops, gradio#12089/gradio#12992). The counter only resets when content shrinks or the height was already stable — once the breaker trips while content is taller than the last reported height, it never recovers.

Progressive rendering of generated results (chunked text A/B, granular matches, similarity bar) trips it. The Space iframe then freezes at a stale height with `scrolling="no"`, so:

- everything below the fold (below "Explore Details & Advanced Options") is clipped and unreachable
- the mouse wheel is completely dead over the app (inner document overflows but its viewport scrolling is suppressed, and cross-origin scroll chaining doesn't kick in)

A fresh tab that never grows past the initial layout works fine — which is why the bug looked tab-dependent.

## Fix

Inject a small `head` script via `launch(head=...)` that reports the true `document.body.scrollHeight` to the iframe-resizer parent whenever it changes (only when embedded, 300 ms poll, no-op outside HF Spaces). Our layout has no viewport-relative heights, so this cannot feed back into a growth loop.

Verified locally that the script is served in the app HTML; `poe all` green (149 tests, 100% coverage).

After merge the Space needs a manual re-sync (workflow broken, see #28).
